### PR TITLE
Fix multiple definition error with whole kernel compile

### DIFF
--- a/hid-ftec.c
+++ b/hid-ftec.c
@@ -6,8 +6,6 @@
 
 #include "hid-ftec.h"
 
-int hid_debug = 1;
-
 #define FTEC_FF		        0x001
 #define FTEC_PEDALS     	0x002
 #define FTEC_LEDS     	    0x004


### PR DESCRIPTION
I'm on an embedded board with no compiler on board, so might as well compile the driver into the kernel itself rather than as a module. When trying to compile the driver with the entire kernel, I run into this error:

```
/opt/gcc-arm-11.2-2022.02-x86_64-arm-none-linux-gnueabihf/bin/arm-none-linux-gnueabihf-ld: drivers/hid/hid-ftec.o: in function `.LANCHOR0':
/home/mike/code/Linux-Kernel_MiSTer/drivers/hid/hid-ftec.c:9: multiple definition of `hid_debug'; drivers/hid/hid-core.o:/home/mike/code/Linux-Kernel_MiSTer/drivers/hid/hid-core.c:44: first defined here
make: *** [Makefile:1183: vmlinux] Error 1
```

Since this variable is already defined in `hid-core.c`, it should probably be removed. This PR does just that and fixes the build. I don't know if this has any other effects though, so let me know. It seems like this change would be necessary if ever upstreamed.