### PR TITLE
readme: Add list of known packaged distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ sudo make install
 This installs the kernel module `hid-fanatec.ko` in the `hid` dir of the running kernel and puts `fanatec.rules` into `/etc/udev/rules.d`. These rules allows access to the device for `users` group and sets deadzone/fuzz to 0 so that any wheel input is detected immediately.
 The driver should get loaded automatically when the wheel is plugged.
 
+### Packaging
+
+If you don't want to compile and install manually, following is a list of known packaged distributions.
+
+| System | Package |
+| ------ | ------- |
+| AUR | [`hid-fanatecff-dkms`](https://aur.archlinux.org/packages/hid-fanatecff-dkms) |
+
 ## Status
 
 ### General


### PR DESCRIPTION
This adds a list of known packaged distributions of `hid-fanatecff` to the README.

For now, this only includes the dkms-based AUR version ([`hid-fanatecff-dkms`](https://aur.archlinux.org/packages/hid-fanatecff-dkms)), which I created a bit ago since it was getting cumbersome to constantly manually re-install after kernel updates across multiple kernels.

Hopefully, this can increase adoption slightly, as it's sometimes scary or unapproachable for new users to manually manage installation of out-of-tree modules. If others are packaging this for other distributions/packaging systems, then they could append to this list, obviously, but I couldn't find any other distributions with a cursory search.