### PR TITLE
Set permissions correctly for Fanatec wheels

### DIFF
--- a/fanatec.rules
+++ b/fanatec.rules
@@ -1,6 +1,7 @@
 ACTION!="add", GOTO="fanatec_end"
 SUBSYSTEM=="hid", DRIVER=="ftec_csl_elite", GOTO="ftec_module_settings"
 SUBSYSTEM=="input", DRIVERS=="ftec_csl_elite", GOTO="ftec_input_settings"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0eb7", MODE="0666"
 GOTO="fanatec_end"
 
 LABEL="ftec_module_settings"


### PR DESCRIPTION
Set the correct permissions for all Fanatec wheels, allowing games to control the wheel. 

This did solved my issue with my Fanatec wheel (with CSL DD) with games like DiRT 4 using Wine/proton. So I now have force feedback working.

In fact, feel free to add DiRT 4 to the list of working games in that case.