### PR TITLE
Also the normal csl base/pedals are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Wheel Base should be set to 'PC mode' for the driver to be selected (CSL Eli
 * 0EB7:0E03 FANATEC CSL Elite Wheel Base
 * 0EB7:0005 FANATEC CSL Elite Wheel Base PS4
 * 0EB7:0020 FANATEC CSL DD / DD Pro / ClubSport DD Wheel Base
-* 0EB7:6204 FANATECCSL Pedals / CSL Elite Pedals
+* 0EB7:6204 FANATEC CSL Pedals / CSL Elite Pedals
 * (experimental: 0EB7:0001 FANATEC ClubSport Wheel Base V2)
 * (experimental: 0EB7:0004 FANATEC Wheel Base / ClubSport Wheel Base V2.5)
 * (experimental: 0EB7:183b FANATEC ClubSport Pedals V3)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Wheel Base should be set to 'PC mode' for the driver to be selected (CSL Eli
 * 0EB7:0E03 FANATEC CSL Elite Wheel Base
 * 0EB7:0005 FANATEC CSL Elite Wheel Base PS4
 * 0EB7:0020 FANATEC CSL DD / DD Pro / ClubSport DD Wheel Base
-* 0EB7:6204 FANATEC CSL Elite Pedals
+* 0EB7:6204 FANATEC CSL Elite Pedals / CSL Pedals
 * (experimental: 0EB7:0001 FANATEC ClubSport Wheel Base V2)
 * (experimental: 0EB7:0004 FANATEC ClubSport Wheel Base V2.5)
 * (experimental: 0EB7:183b FANATEC ClubSport Pedals V3)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Wheel Base should be set to 'PC mode' for the driver to be selected (CSL Eli
 * 0EB7:0020 FANATEC CSL DD / DD Pro / ClubSport DD Wheel Base
 * 0EB7:6204 FANATEC CSL Pedals / CSL Elite Pedals
 * (experimental: 0EB7:0001 FANATEC ClubSport Wheel Base V2)
-* (experimental: 0EB7:0004 FANATEC Wheel Base / ClubSport Wheel Base V2.5)
+* (experimental: 0EB7:0004 FANATEC CSL DD Wheel Base / ClubSport Wheel Base V2.5)
 * (experimental: 0EB7:183b FANATEC ClubSport Pedals V3)
 * (experimental: 0EB7:0006 Podium Wheel Base DD1)
 * (experimental: 0EB7:0007 Podium Wheel Base DD2)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The Wheel Base should be set to 'PC mode' for the driver to be selected (CSL Eli
 * 0EB7:0E03 FANATEC CSL Elite Wheel Base
 * 0EB7:0005 FANATEC CSL Elite Wheel Base PS4
 * 0EB7:0020 FANATEC CSL DD / DD Pro / ClubSport DD Wheel Base
-* 0EB7:6204 FANATEC CSL Elite Pedals / CSL Pedals
+* 0EB7:6204 FANATECCSL Pedals / CSL Elite Pedals
 * (experimental: 0EB7:0001 FANATEC ClubSport Wheel Base V2)
-* (experimental: 0EB7:0004 FANATEC ClubSport Wheel Base V2.5)
+* (experimental: 0EB7:0004 FANATEC Wheel Base / ClubSport Wheel Base V2.5)
 * (experimental: 0EB7:183b FANATEC ClubSport Pedals V3)
 * (experimental: 0EB7:0006 Podium Wheel Base DD1)
 * (experimental: 0EB7:0007 Podium Wheel Base DD2)


### PR DESCRIPTION
- Besides the Elite pedals also the non-elite CSL pedals are just supported.
- Moreover, my Direct-Drive CSL base has device ID `0eb7:0004` as well, while it's not am elite CSL base, but just the "normal" [CSL DD](https://fanatec.com/eu-en/racing-wheels-direct-drive-bases/direct-drive-bases/csl-dd-5-nm) base:

```
Bus 007 Device 017: ID 0eb7:0004 Endor AG FANATEC Wheel
```

Ps. In fact, the [ClubSport Wheel Base v2.5](https://fanatec.com/eu-en/racing-wheels-direct-drive-bases/direct-drive-bases/clubsport-wheel-base-v2.5) is discontinued

Ps. Ps. Maybe the names after ID `0EB7:0020` are not correct...