### PR TITLE
Expose HID PID descriptor via HIDRAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Currently, FF_FRICTION and FF_INERTIA effects have experimental support in this 
 
 Games that are expected to work (tested by me and others more or less regularly):
 
-* AC / ACC (*)
+* AC / ACC (*) / ACE
 * Automobilista 2
 * DiRT 4
 * DiRT Rally 2 / WRC (**)
@@ -135,10 +135,10 @@ To access advanced functions from user space please see the [hid-fanatecff-tools
 ## Troubleshooting
 ### No FFB, nothing on LEDs/display
 Check permissions `ls -l /dev/hidrawXX`, if it is not `0666`, then check with `udevadm test /dev/hidrawXX` if there are any additional rules overwriting the mode set by the `fanatec.rules` file.
-Check correct driver module version is loaded: `modinfo hid-fanatec | grep hidraw`
-Check game log `PROTON_LOG=+hid,+input,+dinput %command%`, ensure that there is a line called `found 3 TLCs`. If it is not there, then a proton/wine version is used that doesn't support multi TLCs (yet).
+Check correct driver module version is loaded: `modinfo hid-fanatec | grep hidraw`.
+Check game log `PROTON_LOG=1 WINEDEBUG=+hid,+input,+dinput %command%`, ensure that there is a line called `found 3 TLCs`. If it is not there, then a proton/wine version is used that doesn't support multi TLCs (yet).
 
-### Game hangs at startup
+### Game hangs/crashes at startup
 * Clear enumerated HID devices: `protontricks -c "wine reg delete 'HKLM\System\CurrentControlSet\Enum\HID' /f" <appid>`
 * If using separated pedals, 'pump' a pedal (to generate input) during game startup (seen in F1 23, AMS2, ??)
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ To access advanced functions from user space please see the [hid-fanatecff-tools
 * Packaging for more distros
 
 ## Troubleshooting
+### No FFB, nothing on LEDs/display
+Check permissions `ls -l /dev/hidrawXX`, if it is not `0666`, then check with `udevadm test /dev/hidrawXX` if there are any additional rules overwriting the mode set by the `fanatec.rules` file.
+Check correct driver module version is loaded: `modinfo hid-fanatec | grep hidraw`
+Check game log `PROTON_LOG=+hid,+input,+dinput %command%`, ensure that there is a line called `found 3 TLCs`. If it is not there, then a proton/wine version is used that doesn't support multi TLCs (yet).
+
+### Game hangs at startup
+* Clear enumerated HID devices: `protontricks -c "wine reg delete 'HKLM\System\CurrentControlSet\Enum\HID' /f" <appid>`
+* If using separated pedals, 'pump' a pedal (to generate input) during game startup (seen in F1 23, AMS2, ??)
+
 ### Large deadzone or chunky input
 Check the deadzone/flatness/fuzz settings:
 ```

--- a/hid-ftec-pid.h
+++ b/hid-ftec-pid.h
@@ -1,0 +1,409 @@
+const u8 rdesc_pid_ffb[] = {
+0x05, 0x0F,                     /*      Usage Page (PID),                   */
+0x09, 0x92,                     /*      Usage (92h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x10,                     /*          Report ID (16),                 */
+0x09, 0x9F,                     /*          Usage (9Fh),                    */
+0x09, 0xA0,                     /*          Usage (A0h),                    */
+0x09, 0xA4,                     /*          Usage (A4h),                    */
+0x09, 0xA5,                     /*          Usage (A5h),                    */
+0x09, 0xA6,                     /*          Usage (A6h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x25, 0x01,                     /*          Logical Maximum (1),            */
+0x75, 0x01,                     /*          Report Size (1),                */
+0x95, 0x05,                     /*          Report Count (5),               */
+0x81, 0x02,                     /*          Input (Variable),               */
+0x95, 0x03,                     /*          Report Count (3),               */
+0x81, 0x03,                     /*          Input (Constant, Variable),     */
+0x09, 0x94,                     /*          Usage (94h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x25, 0x01,                     /*          Logical Maximum (1),            */
+0x75, 0x01,                     /*          Report Size (1),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x81, 0x02,                     /*          Input (Variable),               */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x75, 0x07,                     /*          Report Size (7),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x81, 0x02,                     /*          Input (Variable),               */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x21,                     /*      Usage (21h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x11,                     /*          Report ID (17),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x25,                     /*          Usage (25h),                    */
+0xA1, 0x02,                     /*          Collection (Logical),           */
+0x09, 0x26,                     /*              Usage (26h),                */
+0x09, 0x31,                     /*              Usage (31h),                */
+0x09, 0x40,                     /*              Usage (40h),                */
+0x09, 0x41,                     /*              Usage (41h),                */
+0x09, 0x42,                     /*              Usage (42h),                */
+0x09, 0x43,                     /*              Usage (43h),                */
+0x15, 0x01,                     /*              Logical Minimum (1),        */
+0x25, 0x06,                     /*              Logical Maximum (6),       */
+0x75, 0x08,                     /*              Report Size (8),            */
+0x95, 0x01,                     /*              Report Count (1),           */
+0x91, 0x00,                     /*              Output,                     */
+0xC0,                           /*          End Collection,                 */
+0x09, 0x50,                     /*          Usage (50h),                    */
+0x09, 0x54,                     /*          Usage (54h),                    */
+0x09, 0x51,                     /*          Usage (51h),                    */
+0x09, 0xA7,                     /*          Usage (51h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x66, 0x03, 0x10,               /*          Unit (Seconds),                 */
+0x55, 0xFD,                     /*          Unit Exponent (-3),             */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x03,                     /*          Report Count (4),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x55, 0x00,                     /*          Unit Exponent (0),              */
+0x66, 0x00, 0x00,               /*          Unit,                           */
+0x09, 0x52,                     /*          Usage (52h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x53,                     /*          Usage (53h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x55,                     /*          Usage (55h),                    */
+0xA1, 0x02,                     /*          Collection (Logical),           */
+0x05, 0x01,                     /*              Usage Page (Desktop),       */
+0x09, 0x30,                     /*              Usage (X),                  */
+0x09, 0x31,                     /*              Usage (Y),                  */
+0x15, 0x00,                     /*              Logical Minimum (0),        */
+0x25, 0x01,                     /*              Logical Maximum (1),        */
+0x75, 0x01,                     /*              Report Size (1),            */
+0x95, 0x01,                     /*              Report Count (2),           */
+0x91, 0x02,                     /*              Output (Variable),          */
+0xC0,                           /*          End Collection,                 */
+0x05, 0x0F,                     /*          Usage Page (PID),               */
+0x09, 0x56,                     /*          Usage (56h),                    */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x95, 0x05,                     /*          Report Count (5),               */
+0x91, 0x03,                     /*          Output (Constant, Variable),    */
+0x09, 0x57,                     /*          Usage (57h),                    */
+0xA1, 0x02,                     /*          Collection (Logical),           */
+0x0B, 0x01, 0x00, 0x0A, 0x00,   /*              Usage (000A0001h),          */
+0x0B, 0x02, 0x00, 0x0A, 0x00,   /*              Usage (000A0002h),          */
+0x66, 0x14, 0x00,               /*              Unit (Degrees),             */
+0x55, 0xFE,                     /*              Unit Exponent (-2),         */
+0x15, 0x00,                     /*              Logical Minimum (0),        */
+0x27, 0x3C, 0x8C, 0x00, 0x00,   /*              Logical Maximum (35900),    */
+0x66, 0x00, 0x00,               /*              Unit,                       */
+0x75, 0x10,                     /*              Report Size (16),           */
+0x95, 0x02,                     /*              Report Count (2),           */
+0x91, 0x02,                     /*              Output (Variable),          */
+0x55, 0x00,                     /*              Unit Exponent (0),          */
+0x66, 0x00, 0x00,               /*              Unit,                       */
+0xC0,                           /*          End Collection,                 */
+0xC0,                           /*      End Collection,                     */
+0x05, 0x0F,                     /*      Usage Page (PID),                   */
+0x09, 0x5A,                     /*      Usage (5Ah),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x12,                     /*          Report ID (18),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x5B,                     /*          Usage (5Bh),                    */
+0x09, 0x5D,                     /*          Usage (5Dh),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x95, 0x02,                     /*          Report Count (2),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x5C,                     /*          Usage (5Ch),                    */
+0x09, 0x5E,                     /*          Usage (5Eh),                    */
+0x66, 0x03, 0x10,               /*          Unit (Seconds),                 */
+0x55, 0xFD,                     /*          Unit Exponent (-3),             */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
+0x66, 0x00, 0x00,               /*          Unit,                           */
+0x55, 0x00,                     /*          Unit Exponent (0),              */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x5F,                     /*      Usage (5Fh),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x13,                     /*          Report ID (19),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x23,                     /*          Usage (23h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x25, 0x01,                     /*          Logical Maximum (1),            */
+0x75, 0x04,                     /*          Report Size (4),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x75, 0x04,                     /*          Report Size (4),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x60,                     /*          Usage (60h),                    */
+0x09, 0x61,                     /*          Usage (61h),                    */
+0x09, 0x62,                     /*          Usage (62h),                    */
+0x16, 0x00, 0x80,               /*          Logical Minimum (-32767),       */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x36, 0xF0, 0xD8,               /*          Physical Minimum (-10000),      */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x03,                     /*          Report Count (3),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x63,                     /*          Usage (63h),                    */
+0x09, 0x64,                     /*          Usage (64h),                    */
+0x09, 0x65,                     /*          Usage (65h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x27, 0xFF, 0xFF, 0x00, 0x00,   /*          Logical Maximum (65535),        */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x03,                     /*          Report Count (3),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x6E,                     /*      Usage (6Eh),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x1D,                     /*          Report ID (29),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x70,                     /*          Usage (70h),                    */
+0x16, 0x00, 0x80,               /*          Logical Minimum (-32767),       */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x6F,                     /*          Usage (6Fh),                    */
+0x16, 0x00, 0x80,               /*          Logical Minimum (-32767),       */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x36, 0xF0, 0xD8,               /*          Physical Minimum (-10000),      */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
+0x09, 0x71,                     /*          Usage (71h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x27, 0x3C, 0x8C, 0x00, 0x00,   /*          Logical Maximum (35900),        */
+0x66, 0x14, 0x00,               /*          Unit (Degrees),                 */
+0x55, 0xFE,                     /*          Unit Exponent (-2),             */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x72,                     /*          Usage (72h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x66, 0x03, 0x10,               /*          Unit (Seconds),                 */
+0x55, 0xFD,                     /*          Unit Exponent (-3),             */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x02,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x65, 0x00,                     /*          Unit (None),                    */
+0x55, 0x00,                     /*          Unit Exponent (0),              */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x73,                     /*      Usage (73h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x15,                     /*          Report ID (21),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x35, 0x01,                     /*          Physical Minimum (1),           */
+0x45, 0x28,                     /*          Physical Maximum (40),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x70,                     /*          Usage (70h),                    */
+0x16, 0x00, 0x80,               /*          Logical Minimum (-32767),       */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
+0x36, 0xF0, 0xD8,               /*          Physical Minimum (-10000),      */
+0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0xC0,                           /*      End Collection,                     */
+0x05, 0x0F,                     /*      Usage Page (PID),                   */
+0x09, 0x77,                     /*      Usage (77h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x1A,                     /*          Report ID (26),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x35, 0x01,                     /*          Physical Minimum (1),           */
+0x45, 0x28,                     /*          Physical Maximum (40),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x78,                     /*          Usage (78h),                    */
+0xA1, 0x02,                     /*          Collection (Logical),           */
+0x09, 0x79,                     /*              Usage (79h),                */
+0x09, 0x7A,                     /*              Usage (7Ah),                */
+0x09, 0x7B,                     /*              Usage (7Bh),                */
+0x15, 0x01,                     /*              Logical Minimum (1),        */
+0x25, 0x03,                     /*              Logical Maximum (3),        */
+0x75, 0x08,                     /*              Report Size (8),            */
+0x95, 0x01,                     /*              Report Count (1),           */
+0x91, 0x00,                     /*              Output,                     */
+0xC0,                           /*          End Collection,                 */
+0x09, 0x7C,                     /*          Usage (7Ch),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x46, 0xFF, 0x00,               /*          Physical Maximum (255),         */
+0x91, 0x02,                     /*          Output (Variable),              */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x90,                     /*      Usage (90h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x1B,                     /*          Report ID (27),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x35, 0x01,                     /*          Physical Minimum (1),           */
+0x45, 0x28,                     /*          Physical Maximum (40),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x96,                     /*      Usage (96h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x1C,                     /*          Report ID (28),                 */
+0x09, 0x97,                     /*          Usage (97h),                    */
+0x09, 0x98,                     /*          Usage (98h),                    */
+0x09, 0x99,                     /*          Usage (99h),                    */
+0x09, 0x9A,                     /*          Usage (9Ah),                    */
+0x09, 0x9B,                     /*          Usage (9Bh),                    */
+0x09, 0x9C,                     /*          Usage (9Ch),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x06,                     /*          Logical Maximum (6),            */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x00,                     /*          Output,                         */
+0xC0,                           /*      End Collection,                     */
+0x09, 0xAB,                     /*      Usage (ABh),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x14,                     /*          Report ID (20),                 */
+0x09, 0x25,                     /*          Usage (25h),                    */
+0xA1, 0x02,                     /*          Collection (Logical),           */
+0x09, 0x26,                     /*              Usage (26h),                */
+0x09, 0x31,                     /*              Usage (31h),                */
+0x09, 0x40,                     /*              Usage (40h),                */
+0x09, 0x41,                     /*              Usage (41h),                */
+0x09, 0x42,                     /*              Usage (42h),                */
+0x09, 0x43,                     /*              Usage (43h),                */
+0x25, 0x06,                     /*              Logical Maximum (6),       */
+0x15, 0x01,                     /*              Logical Minimum (1),        */
+0x45, 0x06,                     /*              Physical Maximum (6),      */
+0x35, 0x01,                     /*              Physical Minimum (1),       */
+0x75, 0x08,                     /*              Report Size (8),            */
+0x95, 0x01,                     /*              Report Count (1),           */
+0xB1, 0x00,                     /*              Feature,                    */
+0xC0,                           /*          End Collection,                 */
+0x05, 0x01,                     /*          Usage Page (Desktop),           */
+0x09, 0x3B,                     /*          Usage (Byte Count),             */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x01,               /*          Logical Maximum (511),          */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x46, 0xFF, 0x01,               /*          Physical Maximum (511),         */
+0x75, 0x0A,                     /*          Report Size (10),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0xB1, 0x02,                     /*          Feature (Variable),             */
+0x75, 0x06,                     /*          Report Size (6),                */
+0xB1, 0x01,                     /*          Feature (Constant),             */
+0xC0,                           /*      End Collection,                     */
+0x05, 0x0F,                     /*      Usage Page (PID),                   */
+0x09, 0x89,                     /*      Usage (89h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x16,                     /*          Report ID (22),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x35, 0x01,                     /*          Physical Minimum (1),           */
+0x45, 0x28,                     /*          Physical Maximum (40),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0xB1, 0x02,                     /*          Feature (Variable),             */
+0x09, 0x8B,                     /*          Usage (8Bh),                    */
+0xA1, 0x02,                     /*          Collection (Logical),           */
+0x09, 0x8C,                     /*              Usage (8Ch),                */
+0x09, 0x8D,                     /*              Usage (8Dh),                */
+0x09, 0x8E,                     /*              Usage (8Eh),                */
+0x25, 0x03,                     /*              Logical Maximum (3),        */
+0x15, 0x01,                     /*              Logical Minimum (1),        */
+0x35, 0x01,                     /*              Physical Minimum (1),       */
+0x45, 0x03,                     /*              Physical Maximum (3),       */
+0x75, 0x08,                     /*              Report Size (8),            */
+0x95, 0x01,                     /*              Report Count (1),           */
+0xB1, 0x00,                     /*              Feature,                    */
+0xC0,                           /*          End Collection,                 */
+0x09, 0xAC,                     /*          Usage (ACh),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x27, 0xFF, 0xFF, 0x00, 0x00,   /*          Logical Maximum (65535),        */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x47, 0xFF, 0xFF, 0x00, 0x00,   /*          Physical Maximum (65535),       */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0xB1, 0x00,                     /*          Feature,                        */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x7F,                     /*      Usage (7Fh),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x17,                     /*          Report ID (23),                 */
+0x09, 0x80,                     /*          Usage (80h),                    */
+0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x27, 0xFF, 0xFF, 0x00, 0x00,   /*          Logical Maximum (65535),        */
+0x47, 0xFF, 0xFF, 0x00, 0x00,   /*          Physical Maximum (65535),       */
+0xB1, 0x02,                     /*          Feature (Variable),             */
+0x09, 0x83,                     /*          Usage (83h),                    */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x46, 0xFF, 0x00,               /*          Physical Maximum (255),         */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0xB1, 0x02,                     /*          Feature (Variable),             */
+0x09, 0xA9,                     /*          Usage (A9h),                    */
+0x09, 0xAA,                     /*          Usage (AAh),                    */
+0x75, 0x01,                     /*          Report Size (1),                */
+0x95, 0x02,                     /*          Report Count (2),               */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x25, 0x01,                     /*          Logical Maximum (1),            */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x45, 0x01,                     /*          Physical Maximum (1),           */
+0xB1, 0x02,                     /*          Feature (Variable),             */
+0x75, 0x06,                     /*          Report Size (6),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0xB1, 0x03,                     /*          Feature (Constant, Variable),   */
+0xC0,                           /*      End Collection,                     */
+0x09, 0x7D,                     /*      Usage (7Dh),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x19,                     /*          Report ID (25),                 */
+0x09, 0x7E,                     /*          Usage (7Eh),                    */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0xC0,                           /*      End Collection,                     */
+};

--- a/hid-ftec-pid.h
+++ b/hid-ftec-pid.h
@@ -6,26 +6,16 @@
 0x85, 0x10,                     /*          Report ID (16),                 */
 0x09, 0x9F,                     /*          Usage (9Fh),                    */
 0x09, 0xA0,                     /*          Usage (A0h),                    */
-0x09, 0xA4,                     /*          Usage (A4h),                    */
-0x09, 0xA5,                     /*          Usage (A5h),                    */
-0x09, 0xA6,                     /*          Usage (A6h),                    */
-0x15, 0x00,                     /*          Logical Minimum (0),            */
-0x25, 0x01,                     /*          Logical Maximum (1),            */
-0x75, 0x01,                     /*          Report Size (1),                */
-0x95, 0x05,                     /*          Report Count (5),               */
-0x81, 0x02,                     /*          Input (Variable),               */
-0x95, 0x03,                     /*          Report Count (3),               */
-0x81, 0x03,                     /*          Input (Constant, Variable),     */
 0x09, 0x94,                     /*          Usage (94h),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x25, 0x01,                     /*          Logical Maximum (1),            */
 0x75, 0x01,                     /*          Report Size (1),                */
-0x95, 0x01,                     /*          Report Count (1),               */
+0x95, 0x08,                     /*          Report Count (8),               */
 0x81, 0x02,                     /*          Input (Variable),               */
 0x09, 0x22,                     /*          Usage (22h),                    */
 0x15, 0x01,                     /*          Logical Minimum (1),            */
 0x25, 0x28,                     /*          Logical Maximum (40),           */
-0x75, 0x07,                     /*          Report Size (7),                */
+0x75, 0x07,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x81, 0x02,                     /*          Input (Variable),               */
 0xC0,                           /*      End Collection,                     */
@@ -59,14 +49,15 @@
 0x91, 0x00,                     /*              Output,                     */
 0xC0,                           /*          End Collection,                 */
 0x09, 0x50,                     /*          Usage (50h),                    */
-0x09, 0xA7,                     /*          Usage (A7h),                    */
 0x09, 0x54,                     /*          Usage (54h),                    */
+0x09, 0x51,                     /*          Usage (51h),                    */
+0x09, 0xA7,                     /*          Usage (A7h),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
 0x66, 0x03, 0x10,               /*          Unit (Seconds),                 */
 0x55, 0xFD,                     /*          Unit Exponent (-3),             */
 0x75, 0x10,                     /*          Report Size (16),               */
-0x95, 0x03,                     /*          Report Count (3),               */
+0x95, 0x04,                     /*          Report Count (4),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x55, 0x00,                     /*          Unit Exponent (0),              */
 0x66, 0x00, 0x00,               /*          Unit,                           */
@@ -84,25 +75,20 @@
 0x91, 0x02,                     /*          Output (Variable),              */
 0x09, 0x55,                     /*          Usage (55h),                    */
 0xA1, 0x02,                     /*          Collection (Logical),           */
-0x05, 0x01,                     /*              Usage Page (Desktop),       */
-0x09, 0x30,                     /*              Usage (X),                  */
-0x09, 0x31,                     /*              Usage (Y),                  */
+0x0b, 0x30, 0x00, 0x01, 0x00,   /*              Usage (X),                  */
+0x0b, 0x31, 0x00, 0x01, 0x00,   /*              Usage (Y),                  */
 // 0x09, 0x32,                     /*              Usage (Z),                  */
 0x15, 0x00,                     /*              Logical Minimum (0),        */
 0x25, 0x01,                     /*              Logical Maximum (1),        */
 0x75, 0x01,                     /*              Report Size (1),            */
 0x95, 0x02,                     /*              Report Count (2),           */
 0x91, 0x02,                     /*              Output (Variable),          */
-0x75, 0x02,                     /*              Report Size (2),            */
-0x95, 0x01,                     /*              Report Count (1),           */
-0x91, 0x03,                     /*              Output (Constant, Viriable),*/
 0xC0,                           /*          End Collection,                 */
-0x05, 0x0F,                     /*          Usage Page (PID),               */
 0x09, 0x56,                     /*          Usage (56h),                    */
 0x75, 0x01,                     /*          Report Size (1),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
-0x75, 0x03,                     /*          Report Size (3),                */
+0x75, 0x05,                     /*          Report Size (5),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x03,                     /*          Output (Constant, Variable),    */
 0x09, 0x57,                     /*          Usage (57h),                    */
@@ -162,10 +148,7 @@
 0x09, 0x23,                     /*          Usage (23h),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x25, 0x01,                     /*          Logical Maximum (1),            */
-0x75, 0x04,                     /*          Report Size (4),                */
-0x95, 0x01,                     /*          Report Count (1),               */
-0x91, 0x02,                     /*          Output (Variable),              */
-0x75, 0x04,                     /*          Report Size (4),                */
+0x75, 0x08,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x09, 0x60,                     /*          Usage (60h),                    */
@@ -242,8 +225,6 @@
 0x09, 0x22,                     /*          Usage (22h),                    */
 0x15, 0x01,                     /*          Logical Minimum (1),            */
 0x25, 0x28,                     /*          Logical Maximum (40),           */
-0x35, 0x01,                     /*          Physical Minimum (1),           */
-0x45, 0x28,                     /*          Physical Maximum (40),          */
 0x75, 0x08,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
@@ -290,6 +271,7 @@
 0x91, 0x02,                     /*          Output (Variable),              */
 0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
+#ifdef BLOCK_FREE_REPORT
 0x09, 0x90,                     /*      Usage (90h),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
 0x85, 0x1B,                     /*          Report ID (27),                 */
@@ -300,9 +282,10 @@
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0xC0,                           /*      End Collection,                     */
+#endif
 0x09, 0x96,                     /*      Usage (96h),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
-0x85, 0x1C,                     /*          Report ID (28),                 */
+0x85, 0x10,                     /*          Report ID (16),                 */
 0x09, 0x97,                     /*          Usage (97h),                    */
 0x09, 0x98,                     /*          Usage (98h),                    */
 0x09, 0x99,                     /*          Usage (99h),                    */
@@ -315,6 +298,7 @@
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x00,                     /*          Output,                         */
 0xC0,                           /*      End Collection,                     */
+#ifdef CREATE_NEW_EFFECT_REPORT
 0x09, 0xAB,                     /*      Usage (ABh),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
 0x85, 0x14,                     /*          Report ID (20),                 */
@@ -350,6 +334,8 @@
 0xB1, 0x01,                     /*          Feature (Constant),             */
 0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
+#endif
+#ifdef BLOCK_LOAD_REPORT
 0x05, 0x0F,                     /*      Usage Page (PID),                   */
 0x09, 0x89,                     /*      Usage (89h),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
@@ -385,6 +371,8 @@
 0xB1, 0x00,                     /*          Feature,                        */
 0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
+#endif
+#ifdef DEVICE_POOL_REPORT
 0x09, 0x7F,                     /*      Usage (7Fh),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
 0x85, 0x17,                     /*          Report ID (23),                 */
@@ -410,6 +398,7 @@
 0x95, 0x01,                     /*          Report Count (1),               */
 0xB1, 0x03,                     /*          Feature (Constant, Variable),   */
 0xC0,                           /*      End Collection,                     */
+#endif
 0x09, 0x7D,                     /*      Usage (7Dh),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
 0x85, 0x19,                     /*          Report ID (25),                 */

--- a/hid-ftec-pid.h
+++ b/hid-ftec-pid.h
@@ -1,4 +1,5 @@
-const u8 rdesc_pid_ffb[] = {
+0x35, 0x00,                     /*      Physical Minimum (0),               */
+0x45, 0x00,                     /*      Physical Maximum (0),               */
 0x05, 0x0F,                     /*      Usage Page (PID),                   */
 0x09, 0x92,                     /*      Usage (92h),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
@@ -40,35 +41,38 @@ const u8 rdesc_pid_ffb[] = {
 0x09, 0x25,                     /*          Usage (25h),                    */
 0xA1, 0x02,                     /*          Collection (Logical),           */
 0x09, 0x26,                     /*              Usage (26h),                */
+0x09, 0x27,                     /*              Usage (27h),                */
+0x09, 0x28,                     /*              Usage (28h),                */
+0x09, 0x30,                     /*              Usage (30h),                */
 0x09, 0x31,                     /*              Usage (31h),                */
+0x09, 0x32,                     /*              Usage (32h),                */
+0x09, 0x33,                     /*              Usage (33h),                */
+0x09, 0x34,                     /*              Usage (34h),                */
 0x09, 0x40,                     /*              Usage (40h),                */
 0x09, 0x41,                     /*              Usage (41h),                */
 0x09, 0x42,                     /*              Usage (42h),                */
 0x09, 0x43,                     /*              Usage (43h),                */
 0x15, 0x01,                     /*              Logical Minimum (1),        */
-0x25, 0x06,                     /*              Logical Maximum (6),       */
+0x25, 0x12,                     /*              Logical Maximum (12),       */
 0x75, 0x08,                     /*              Report Size (8),            */
 0x95, 0x01,                     /*              Report Count (1),           */
 0x91, 0x00,                     /*              Output,                     */
 0xC0,                           /*          End Collection,                 */
 0x09, 0x50,                     /*          Usage (50h),                    */
+0x09, 0xA7,                     /*          Usage (A7h),                    */
 0x09, 0x54,                     /*          Usage (54h),                    */
-0x09, 0x51,                     /*          Usage (51h),                    */
-0x09, 0xA7,                     /*          Usage (51h),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
 0x66, 0x03, 0x10,               /*          Unit (Seconds),                 */
 0x55, 0xFD,                     /*          Unit Exponent (-3),             */
 0x75, 0x10,                     /*          Report Size (16),               */
-0x95, 0x03,                     /*          Report Count (4),               */
+0x95, 0x03,                     /*          Report Count (3),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x55, 0x00,                     /*          Unit Exponent (0),              */
 0x66, 0x00, 0x00,               /*          Unit,                           */
 0x09, 0x52,                     /*          Usage (52h),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
-0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
-0x35, 0x00,                     /*          Physical Minimum (0),           */
-0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x26, 0x64, 0x00,               /*          Logical Maximum (100),          */
 0x75, 0x08,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
@@ -83,17 +87,23 @@ const u8 rdesc_pid_ffb[] = {
 0x05, 0x01,                     /*              Usage Page (Desktop),       */
 0x09, 0x30,                     /*              Usage (X),                  */
 0x09, 0x31,                     /*              Usage (Y),                  */
+// 0x09, 0x32,                     /*              Usage (Z),                  */
 0x15, 0x00,                     /*              Logical Minimum (0),        */
 0x25, 0x01,                     /*              Logical Maximum (1),        */
 0x75, 0x01,                     /*              Report Size (1),            */
-0x95, 0x01,                     /*              Report Count (2),           */
+0x95, 0x02,                     /*              Report Count (2),           */
 0x91, 0x02,                     /*              Output (Variable),          */
+0x75, 0x02,                     /*              Report Size (2),            */
+0x95, 0x01,                     /*              Report Count (1),           */
+0x91, 0x03,                     /*              Output (Constant, Viriable),*/
 0xC0,                           /*          End Collection,                 */
 0x05, 0x0F,                     /*          Usage Page (PID),               */
 0x09, 0x56,                     /*          Usage (56h),                    */
+0x75, 0x01,                     /*          Report Size (1),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
-0x95, 0x05,                     /*          Report Count (5),               */
+0x75, 0x03,                     /*          Report Size (3),                */
+0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x03,                     /*          Output (Constant, Variable),    */
 0x09, 0x57,                     /*          Usage (57h),                    */
 0xA1, 0x02,                     /*          Collection (Logical),           */
@@ -103,7 +113,6 @@ const u8 rdesc_pid_ffb[] = {
 0x55, 0xFE,                     /*              Unit Exponent (-2),         */
 0x15, 0x00,                     /*              Logical Minimum (0),        */
 0x27, 0x3C, 0x8C, 0x00, 0x00,   /*              Logical Maximum (35900),    */
-0x66, 0x00, 0x00,               /*              Unit,                       */
 0x75, 0x10,                     /*              Report Size (16),           */
 0x95, 0x02,                     /*              Report Count (2),           */
 0x91, 0x02,                     /*              Output (Variable),          */
@@ -124,9 +133,9 @@ const u8 rdesc_pid_ffb[] = {
 0x09, 0x5B,                     /*          Usage (5Bh),                    */
 0x09, 0x5D,                     /*          Usage (5Dh),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
-0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
-0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
 0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
+0x75, 0x10,                     /*          Report Size (16),               */
 0x95, 0x02,                     /*          Report Count (2),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x09, 0x5C,                     /*          Usage (5Ch),                    */
@@ -135,6 +144,7 @@ const u8 rdesc_pid_ffb[] = {
 0x55, 0xFD,                     /*          Unit Exponent (-3),             */
 0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
 0x75, 0x10,                     /*          Report Size (16),               */
+0x95, 0x02,                     /*          Report Count (2),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x45, 0x00,                     /*          Physical Maximum (0),           */
 0x66, 0x00, 0x00,               /*          Unit,                           */
@@ -178,6 +188,7 @@ const u8 rdesc_pid_ffb[] = {
 0x75, 0x10,                     /*          Report Size (16),               */
 0x95, 0x03,                     /*          Report Count (3),               */
 0x91, 0x02,                     /*          Output (Variable),              */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
 0x09, 0x6E,                     /*      Usage (6Eh),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
@@ -189,7 +200,7 @@ const u8 rdesc_pid_ffb[] = {
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x09, 0x70,                     /*          Usage (70h),                    */
-0x16, 0x00, 0x80,               /*          Logical Minimum (-32767),       */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x26, 0xFF, 0x7F,               /*          Logical Maximum (32767),        */
 0x35, 0x00,                     /*          Physical Minimum (0),           */
 0x46, 0x10, 0x27,               /*          Physical Maximum (10000),       */
@@ -220,7 +231,7 @@ const u8 rdesc_pid_ffb[] = {
 0x66, 0x03, 0x10,               /*          Unit (Seconds),                 */
 0x55, 0xFD,                     /*          Unit Exponent (-3),             */
 0x75, 0x10,                     /*          Report Size (16),               */
-0x95, 0x02,                     /*          Report Count (1),               */
+0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0x65, 0x00,                     /*          Unit (None),                    */
 0x55, 0x00,                     /*          Unit Exponent (0),              */
@@ -244,6 +255,8 @@ const u8 rdesc_pid_ffb[] = {
 0x75, 0x10,                     /*          Report Size (16),               */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
 0x05, 0x0F,                     /*      Usage Page (PID),                   */
 0x09, 0x77,                     /*      Usage (77h),                        */
@@ -257,6 +270,8 @@ const u8 rdesc_pid_ffb[] = {
 0x75, 0x08,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
+0x35, 0x00,                     /*          Physical Minimum (0),           */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
 0x09, 0x78,                     /*          Usage (78h),                    */
 0xA1, 0x02,                     /*          Collection (Logical),           */
 0x09, 0x79,                     /*              Usage (79h),                */
@@ -271,18 +286,16 @@ const u8 rdesc_pid_ffb[] = {
 0x09, 0x7C,                     /*          Usage (7Ch),                    */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
-0x35, 0x00,                     /*          Physical Minimum (0),           */
 0x46, 0xFF, 0x00,               /*          Physical Maximum (255),         */
 0x91, 0x02,                     /*          Output (Variable),              */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
 0x09, 0x90,                     /*      Usage (90h),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
 0x85, 0x1B,                     /*          Report ID (27),                 */
 0x09, 0x22,                     /*          Usage (22h),                    */
-0x25, 0x28,                     /*          Logical Maximum (40),           */
 0x15, 0x01,                     /*          Logical Minimum (1),            */
-0x35, 0x01,                     /*          Physical Minimum (1),           */
-0x45, 0x28,                     /*          Physical Maximum (40),          */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
 0x75, 0x08,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
@@ -308,15 +321,19 @@ const u8 rdesc_pid_ffb[] = {
 0x09, 0x25,                     /*          Usage (25h),                    */
 0xA1, 0x02,                     /*          Collection (Logical),           */
 0x09, 0x26,                     /*              Usage (26h),                */
+0x09, 0x27,                     /*              Usage (27h),                */
+0x09, 0x28,                     /*              Usage (28h),                */
+0x09, 0x30,                     /*              Usage (30h),                */
 0x09, 0x31,                     /*              Usage (31h),                */
+0x09, 0x32,                     /*              Usage (32h),                */
+0x09, 0x33,                     /*              Usage (33h),                */
+0x09, 0x34,                     /*              Usage (34h),                */
 0x09, 0x40,                     /*              Usage (40h),                */
 0x09, 0x41,                     /*              Usage (41h),                */
 0x09, 0x42,                     /*              Usage (42h),                */
 0x09, 0x43,                     /*              Usage (43h),                */
-0x25, 0x06,                     /*              Logical Maximum (6),       */
 0x15, 0x01,                     /*              Logical Minimum (1),        */
-0x45, 0x06,                     /*              Physical Maximum (6),      */
-0x35, 0x01,                     /*              Physical Minimum (1),       */
+0x25, 0x12,                     /*              Logical Maximum (12),       */
 0x75, 0x08,                     /*              Report Size (8),            */
 0x95, 0x01,                     /*              Report Count (1),           */
 0xB1, 0x00,                     /*              Feature,                    */
@@ -325,13 +342,13 @@ const u8 rdesc_pid_ffb[] = {
 0x09, 0x3B,                     /*          Usage (Byte Count),             */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x26, 0xFF, 0x01,               /*          Logical Maximum (511),          */
-0x35, 0x00,                     /*          Physical Minimum (0),           */
 0x46, 0xFF, 0x01,               /*          Physical Maximum (511),         */
 0x75, 0x0A,                     /*          Report Size (10),               */
 0x95, 0x01,                     /*          Report Count (1),               */
 0xB1, 0x02,                     /*          Feature (Variable),             */
 0x75, 0x06,                     /*          Report Size (6),                */
 0xB1, 0x01,                     /*          Feature (Constant),             */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
 0x05, 0x0F,                     /*      Usage Page (PID),                   */
 0x09, 0x89,                     /*      Usage (89h),                        */
@@ -366,6 +383,7 @@ const u8 rdesc_pid_ffb[] = {
 0x75, 0x10,                     /*          Report Size (16),               */
 0x95, 0x01,                     /*          Report Count (1),               */
 0xB1, 0x00,                     /*          Feature,                        */
+0x45, 0x00,                     /*          Physical Maximum (0),           */
 0xC0,                           /*      End Collection,                     */
 0x09, 0x7F,                     /*      Usage (7Fh),                        */
 0xA1, 0x02,                     /*      Collection (Logical),               */
@@ -374,13 +392,10 @@ const u8 rdesc_pid_ffb[] = {
 0x75, 0x10,                     /*          Report Size (16),               */
 0x95, 0x01,                     /*          Report Count (1),               */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
-0x35, 0x00,                     /*          Physical Minimum (0),           */
 0x27, 0xFF, 0xFF, 0x00, 0x00,   /*          Logical Maximum (65535),        */
-0x47, 0xFF, 0xFF, 0x00, 0x00,   /*          Physical Maximum (65535),       */
 0xB1, 0x02,                     /*          Feature (Variable),             */
 0x09, 0x83,                     /*          Usage (83h),                    */
-0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
-0x46, 0xFF, 0x00,               /*          Physical Maximum (255),         */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (40),          */
 0x75, 0x08,                     /*          Report Size (8),                */
 0x95, 0x01,                     /*          Report Count (1),               */
 0xB1, 0x02,                     /*          Feature (Variable),             */
@@ -390,8 +405,6 @@ const u8 rdesc_pid_ffb[] = {
 0x95, 0x02,                     /*          Report Count (2),               */
 0x15, 0x00,                     /*          Logical Minimum (0),            */
 0x25, 0x01,                     /*          Logical Maximum (1),            */
-0x35, 0x00,                     /*          Physical Minimum (0),           */
-0x45, 0x01,                     /*          Physical Maximum (1),           */
 0xB1, 0x02,                     /*          Feature (Variable),             */
 0x75, 0x06,                     /*          Report Size (6),                */
 0x95, 0x01,                     /*          Report Count (1),               */
@@ -406,4 +419,20 @@ const u8 rdesc_pid_ffb[] = {
 0x95, 0x01,                     /*          Report Count (1),               */
 0x91, 0x02,                     /*          Output (Variable),              */
 0xC0,                           /*      End Collection,                     */
-};
+0x09, 0x74,                     /*      Usage (74h),                        */
+0xA1, 0x02,                     /*      Collection (Logical),               */
+0x85, 0x18,                     /*          Report ID (24),                 */
+0x09, 0x22,                     /*          Usage (22h),                    */
+0x15, 0x01,                     /*          Logical Minimum (1),            */
+0x25, 0x28,                     /*          Logical Maximum (40),           */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (1),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0x09, 0x75,                     /*          Usage (75h),                    */
+0x09, 0x76,                     /*          Usage (76h),                    */
+0x15, 0x00,                     /*          Logical Minimum (0),            */
+0x26, 0xFF, 0x00,               /*          Logical Maximum (255),          */
+0x75, 0x08,                     /*          Report Size (8),                */
+0x95, 0x01,                     /*          Report Count (2),               */
+0x91, 0x02,                     /*          Output (Variable),              */
+0xC0,                           /*      End Collection,                     */

--- a/hid-ftec.c
+++ b/hid-ftec.c
@@ -1,14 +1,20 @@
 #include <linux/device.h>
 #include <linux/usb.h>
 #include <linux/hid.h>
+#include <linux/hidraw.h>
 #include <linux/module.h>
 #include <linux/input.h>
 
 #include "hid-ftec.h"
+#include "hid-ftec-pid.h"
 
 // adjustabel initial value for break load cell
 int init_load = 4;
 module_param(init_load, int, 0);
+// expose PID HID descriptor via hidraw
+bool hidraw_pid = true;
+module_param(hidraw_pid, bool, 1);
+
 
 static u8 ftec_get_load(struct hid_device *hid)
 {
@@ -182,21 +188,353 @@ static int ftec_init(struct hid_device *hdev) {
 	return 0;
 }
 
+static int ftec_client_ll_parse(struct hid_device *hdev)
+{
+	struct ftec_drv_data *drv_data = hdev->driver_data;
+	u8 *rdesc = drv_data->client.rdesc, *ref_pos, *ref_end, *pos, *end;
+	unsigned rsize, depth = 0;
+	u8 size, report_id = 255;
+
+	for (ref_pos = drv_data->hid->dev_rdesc,
+			ref_end = drv_data->hid->dev_rdesc + drv_data->hid->dev_rsize,
+			pos = rdesc, end = rdesc + sizeof(drv_data->client.rdesc);
+			ref_pos != ref_end && pos != end;
+			ref_pos += size + 1, pos += size + 1) {
+
+		if (*ref_pos == 0xC0 && --depth == 0 && report_id < 2) {
+			// inject the pid ffb collection
+			if (pos + sizeof(rdesc_pid_ffb) > end) {
+				hid_err(hdev, "Need %lu bytes to inject ffb\n", sizeof(rdesc_pid_ffb) );
+				return 0;
+			}
+			memcpy(pos, rdesc_pid_ffb, sizeof(rdesc_pid_ffb));
+			pos += sizeof(rdesc_pid_ffb);
+		}
+
+		size = (*ref_pos & 0x03);
+		if (size == 3) size = 4;
+		if (ref_pos + size > ref_end || pos + size > end)
+		{
+		    hid_err(hdev, "Need %d bytes to read item value\n", size );
+		    return 0;
+		}
+
+		memcpy(pos, ref_pos, size + 1);
+
+		if (*ref_pos == 0x85)
+			report_id = *(ref_pos + 1);
+		if (*ref_pos == 0xA1)
+			++depth;
+	}
+
+	rsize = pos - rdesc;
+	return hid_parse_report(hdev, rdesc, rsize);
+}
+
+static int ftec_client_ll_start(struct hid_device *hdev)
+{
+	return 0;
+}
+
+static void ftec_client_ll_stop(struct hid_device *hdev)
+{
+}
+
+static int ftec_client_ll_open(struct hid_device *hdev)
+{
+	struct ftec_drv_data *drv_data = hdev->driver_data;
+	drv_data->client.opened++;
+	return 0;
+}
+
+static void ftec_client_ll_close(struct hid_device *hdev)
+{
+	struct ftec_drv_data *drv_data = hdev->driver_data;
+	drv_data->client.opened--;
+}
+
+static int ftec_client_ll_raw_request(struct hid_device *hdev,
+				unsigned char reportnum, u8 *buf,
+				size_t count, unsigned char report_type,
+				int reqtype)
+{
+	struct ftec_drv_data *drv_data = hdev->driver_data;
+	struct hid_input *hidinput = list_entry(drv_data->hid->inputs.next, struct hid_input, list);
+	struct input_dev *inputdev = hidinput->input;
+	struct ff_device *ff = hidinput->input->ff;
+	struct ff_effect *effect;
+	// effects as listed in usage 20
+	const u8 effects[] = {
+		FF_CONSTANT,
+		FF_SINE,
+		FF_SPRING,
+		FF_DAMPER,
+		FF_INERTIA,
+		FF_FRICTION,
+	};
+
+	if (reportnum <= 2 || reportnum == 255) {
+		// forward these reports directly to the device
+		return hid_hw_output_report(drv_data->hid, buf, count);
+	}
+
+	if (0) {
+		printk(KERN_CONT "ftec_client_ll_raw_request num %2u, count %2lu, rep type %#02x, req type %#02x, data ", reportnum, count, report_type, reqtype);
+		// only print set reports
+		if (reqtype == 0x9) {
+			for (int i = 0; i < count; ++i)
+				printk(KERN_CONT " %#02x", buf[i]);
+		}
+		printk(KERN_CONT "\n");
+	}
+
+#define PID_REPORT_SET_EFFECT 		17  // usage 0x21
+#define PID_REPORT_SET_CONDITION 	19  // usage 0x5f
+#define PID_REPORT_CREATE_NEW_EFFECT 	20  // usage 0xab
+#define PID_REPORT_SET_CONSTANT_FORCE   21  // usage 0x73
+#define PID_REPORT_BLOCK_LOAD 		22  // usage 0x89
+#define PID_REPORT_EFFECT_OPERATION     26  // usage 0x77
+#define PID_REPORT_BLOCK_FREE 		27  // usage 0x90
+#define PID_REPORT_DEVICE_CONTROL 	28  // usage 0x96
+#define PID_REPORT_SET_PERIODIC 	29  // usage 0x6e
+#define check_idx if (idx >= ARRAY_SIZE(drv_data->client.effects)) { \
+			hid_err(hdev, "Invalid index %lu\n", idx);   \
+			return 0;                                    \
+                  }
+#define get_effect check_idx \
+	effect = &drv_data->client.effects[idx];
+#define check_count(num) if (count != num) { \
+			hid_err(hdev, "Invalid count %lu\n", count);  \
+			return 0;                                     \
+                  }
+
+	switch (reportnum) {
+	case PID_REPORT_CREATE_NEW_EFFECT: {
+		size_t type = buf[1];
+		size_t idx = type-1;
+
+		get_effect
+
+		if (effect->id != 0) {
+			// already allocated effect, stop the old in favor of the new one?
+			(void)ff->playback(inputdev, effect->id, 0);
+		}
+
+		effect->id = type;
+		if (effects[idx] == FF_SINE) {
+			effect->type = FF_PERIODIC;
+			effect->u.periodic.waveform = effects[idx];
+		} else {
+			effect->type = effects[idx];
+		}
+
+		// store current effect to continue with it in report 22
+		drv_data->client.current_effect = effect;
+		break;
+	}
+	case PID_REPORT_BLOCK_LOAD: {
+		check_count(5)
+
+		buf[0] = reportnum;
+		effect = drv_data->client.current_effect;
+		if (effect == NULL || effect->id == 0) {
+			buf[1] = 0x00;
+			buf[2] = 0x02;
+		} else {
+			buf[1] = effect->id;  // effect id
+			buf[2] = 0x01;        // load status: 1 success, 2 full, 3 error
+			drv_data->client.current_effect = NULL;
+		}
+		buf[3] = 0xff;
+		buf[4] = 0xff;
+		break;
+	}
+	case PID_REPORT_SET_CONSTANT_FORCE: {
+		size_t idx = buf[1]-1;
+		check_count(4)
+
+		get_effect
+
+		effect->u.constant.level = ((s16)buf[3]) << 8 | buf[2];
+		(void)ff->upload(inputdev, effect, NULL);
+		break;
+	}
+	case PID_REPORT_SET_CONDITION: {
+		size_t idx = buf[1]-1;
+		check_count(15)
+
+		get_effect
+
+		struct ff_condition_effect *condition = &effect->u.condition[buf[2]&0x1];
+		condition->center = ((s16)buf[4]) << 8 | buf[3];
+		condition->right_coeff = ((s16)buf[6]) << 8 | buf[5];
+		condition->left_coeff = ((s16)buf[8]) << 8 | buf[7];
+		condition->right_saturation = ((u16)buf[10]) << 8 | buf[9];
+		condition->left_saturation = ((u16)buf[12]) << 8 | buf[11];
+		condition->deadband = ((u16)buf[14]) << 8 | buf[13];
+		(void)ff->upload(inputdev, effect, NULL);
+		break;
+	}
+	case PID_REPORT_SET_PERIODIC: {
+		size_t idx = buf[1]-1;
+		check_count(11)
+		get_effect
+
+		effect->u.periodic.period = ((u16)buf[10]) << 8 | buf[9];
+		// FIXME: what's this all about ??
+		if (effect->u.periodic.period != 0) {
+			effect->u.periodic.magnitude = ((s16)buf[4]) << 8 | buf[3];
+			effect->u.periodic.offset = ((s16)buf[6]) << 8 | buf[5];
+			effect->u.periodic.phase = ((u16)buf[8] << 8 | buf[7]) * 0x10000 / 18000;
+		} else {
+			effect->type =  FF_CONSTANT;
+			effect->u.constant.level = ((s16)buf[4]) << 8 | buf[3];
+		}
+		(void)!ff->upload(inputdev, effect, NULL);
+		break;
+	}
+	case PID_REPORT_SET_EFFECT: {
+		size_t idx = buf[1]-1;
+		check_count(16)
+		get_effect
+
+		u16 duration = buf[4] << 8 | buf[3];
+		effect->replay.length = duration == 0xffff ? 0 : duration;
+		effect->trigger.interval = buf[6] << 8 | buf[5];
+		effect->trigger.button = buf[10];
+
+		// FIXME: hardcoded for now, not yet figured out what games do here
+		effect->direction = 0x4000;  // ((u16)buf[13] << 8 | buf[12]) * 0x10000 / 18000;
+		(void)ff->upload(inputdev, effect, NULL);
+		break;
+	}
+	case PID_REPORT_EFFECT_OPERATION: {
+		size_t idx = buf[1]-1;
+		check_count(4)
+		get_effect
+
+		// Effect Operation: Op Effect Start/Start Solo/Stop
+		if (buf[2] == 0x2) {
+			// stop all other effects
+			struct ff_effect *other_effect;
+			for (size_t i = 0; i < ARRAY_SIZE(drv_data->client.effects); ++i) {
+				other_effect = &drv_data->client.effects[i];
+				if (other_effect->id > 0 && other_effect != effect) {
+					(void)ff->playback(inputdev, other_effect->id, 0);
+				}
+			}
+
+		}
+		if (effect->id == 0) {
+			hid_err(hdev, "Invalid effect id %u\n", effect->id);
+			return 0;
+		}
+		if (effect->type == 0) {
+			hid_err(hdev, "Invalid type %u\n", effect->type);
+			return 0;
+		}
+		(void)ff->playback(inputdev, effect->id, buf[3]);
+		break;
+	}
+	case PID_REPORT_DEVICE_CONTROL: {
+		if (buf[1] == 0x4) {
+			// reset: stop and unload all effects
+			for (size_t i = 0; i < ARRAY_SIZE(drv_data->client.effects); ++i) {
+				effect = &drv_data->client.effects[i];
+				if (effect->id > 0) {
+					(void)ff->playback(inputdev, effect->id, 0);
+					effect->id = 0;
+				}
+			}
+		}
+		break;
+	}
+	case PID_REPORT_BLOCK_FREE: {
+		size_t idx = buf[1]-1;
+		get_effect
+
+		if (effect->id > 0) {
+			// FIXME: also stop playing the effect??
+			(void)ff->playback(inputdev, effect->id, 0);
+			effect->id = 0;
+		}
+		break;
+	}
+	default:
+		 printk("Not implemented report %u\n", reportnum);
+	}
+	return count;
+}
+
+static const struct hid_ll_driver ftec_client_ll_driver = {
+	.parse = ftec_client_ll_parse,
+	.start = ftec_client_ll_start,
+	.stop = ftec_client_ll_stop,
+	.open = ftec_client_ll_open,
+	.close = ftec_client_ll_close,
+	.raw_request = ftec_client_ll_raw_request,
+};
+
+static struct hid_device *ftec_create_client_hid(struct hid_device *hdev)
+{
+	struct hid_device *client_hdev;
+
+	client_hdev = hid_allocate_device();
+	if (IS_ERR(client_hdev))
+		return client_hdev;
+
+	client_hdev->ll_driver = &ftec_client_ll_driver;
+	client_hdev->dev.parent = hdev->dev.parent;
+	client_hdev->bus = hdev->bus;
+	client_hdev->vendor = hdev->vendor;
+	client_hdev->product = hdev->product;
+	client_hdev->version = hdev->version;
+	client_hdev->type = hdev->type;
+	client_hdev->country = hdev->country;
+	strscpy(client_hdev->name, hdev->name,
+			sizeof(client_hdev->name));
+	strscpy(client_hdev->phys, hdev->phys,
+			sizeof(client_hdev->phys));
+	/*
+	 * Since we use the same device info than the real interface to
+	 * trick userspace, we will be calling ftec_probe recursively.
+	 * We need to recognize the client interface somehow.
+	 */
+	client_hdev->group = HID_GROUP_STEAM;
+	return client_hdev;
+}
+
 static int ftec_probe(struct hid_device *hdev, const struct hid_device_id *id)
 {
 	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);
 	__u8 iface_num = iface->cur_altsetting->desc.bInterfaceNumber;
+	unsigned int connect_mask = HID_CONNECT_HIDINPUT | HID_CONNECT_HIDDEV;
 	struct ftec_drv_data *drv_data;
-	unsigned int connect_mask = HID_CONNECT_DEFAULT;
 	int ret;
 
 	dbg_hid("%s: ifnum %d\n", __func__, iface_num);
+
+	ret = hid_parse(hdev);
+	if (ret) {
+		hid_err(hdev, "%s:parse of hid interface failed\n", __func__);
+		return ret;
+	}
+
+	/*
+	 * The virtual client_dev is only used for hidraw.
+	 * Also avoid the recursive probe.
+	 * Note: this technique is 'stolen' from hid-steam
+	 */
+	if (hdev->group == HID_GROUP_STEAM) {
+		return hid_hw_start(hdev, HID_CONNECT_HIDRAW);
+	}
 
 	drv_data = kzalloc(sizeof(struct ftec_drv_data), GFP_KERNEL);
 	if (!drv_data) {
 		hid_err(hdev, "Insufficient memory, cannot allocate driver data\n");
 		return -ENOMEM;
 	}
+	memset(&drv_data->client, 0, sizeof(drv_data->client));
 	drv_data->quirks = id->driver_data;
 	drv_data->min_range = 90;
 	drv_data->max_range = 1090; // technically max_range is 1080, but 1090 is used as 'auto'
@@ -212,14 +550,12 @@ static int ftec_probe(struct hid_device *hdev, const struct hid_device_id *id)
 
 	hid_set_drvdata(hdev, (void *)drv_data);
 
-	ret = hid_parse(hdev);
-	if (ret) {
-		hid_err(hdev, "parse failed\n");
-		goto err_free;
+	if (drv_data->quirks & FTEC_PEDALS || !hidraw_pid) {
+		connect_mask |= HID_CONNECT_HIDRAW;
 	}
 
 	if (drv_data->quirks & FTEC_FF) {
-		connect_mask &= ~HID_CONNECT_FF;
+		connect_mask |= HID_CONNECT_FF;
 	}
 
 	ret = hid_hw_start(hdev, connect_mask);
@@ -233,21 +569,34 @@ static int ftec_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		hid_err(hdev, "hw init failed\n");
 		goto err_stop;
 	}
-	
+
 	if (drv_data->quirks & FTEC_TUNING_MENU) {
 		/* Open the device to receive reports with tuning menu data */
 		ret = hid_hw_open(hdev);
 		if (ret < 0) {
 			hid_err(hdev, "hw open failed\n");
+			goto err_client;
+		}
+	}
+
+	if (drv_data->quirks & FTEC_FF && hidraw_pid) {
+		drv_data->client.hdev = ftec_create_client_hid(hdev);
+		if (IS_ERR(drv_data->client.hdev)) {
+			ret = PTR_ERR(drv_data->client.hdev);
 			goto err_stop;
 		}
+		drv_data->client.hdev->driver_data = drv_data;
+
+		ret = hid_add_device(drv_data->client.hdev);
+		if (ret)
+			goto err_client;
 	}
 
 	if (drv_data->quirks & FTEC_FF) {
 		ret = ftecff_init(hdev);
 		if (ret) {
 			hid_err(hdev, "ff init failed\n");
-			goto err_stop;
+			goto err_client;
 		}
 	}
 
@@ -278,8 +627,9 @@ static int ftec_probe(struct hid_device *hdev, const struct hid_device_id *id)
 
 	return 0;
 
-//err_close:
-//	hid_hw_close(hdev);
+err_client:
+	if (drv_data->client.hdev)
+		hid_destroy_device(drv_data->client.hdev);
 err_stop:
 	hid_hw_stop(hdev);
 err_free:
@@ -290,6 +640,16 @@ err_free:
 static void ftec_remove(struct hid_device *hdev)
 {
 	struct ftec_drv_data *drv_data = hid_get_drvdata(hdev);
+
+	if (!drv_data || hdev->group == HID_GROUP_STEAM) {
+		hid_hw_stop(hdev);
+		return;
+	}
+
+	if (drv_data->client.hdev) {
+		hid_destroy_device(drv_data->client.hdev);
+		drv_data->client.hdev = NULL;
+	}
     
 	if (drv_data->quirks & FTEC_PEDALS) {
 		device_remove_file(&hdev->dev, &dev_attr_load);
@@ -312,8 +672,12 @@ static void ftec_remove(struct hid_device *hdev)
 
 static int ftec_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data, int size) {
 	struct ftec_drv_data *drv_data = hid_get_drvdata(hdev);
+	if (drv_data->client.opened) {
+		// printk("ftec_raw_event %#02x %i\n", report->id, size);
+		hidraw_report_event(drv_data->client.hdev, data, size);
+	}
 	if (drv_data->quirks & FTEC_FF) {
-		return ftecff_raw_event(hdev, report, data, size);
+		ftecff_raw_event(hdev, report, data, size);
 	}
 	return 0;
 }

--- a/hid-ftec.c
+++ b/hid-ftec.c
@@ -627,8 +627,8 @@ static int ftec_client_ll_raw_request(struct hid_device *hdev,
 				if (drv_data->client.effects[i].id) {
 					(void)ff->playback(inputdev, drv_data->client.effects[i].id, 0);
 					ftec_client_report_state(drv_data->client.hdev, 0x2, 0x0, drv_data->client.effects[i].id);
-					memset(&drv_data->client.effects[i], 0, sizeof(struct ff_effect));
 				}
+				memset(&drv_data->client.effects[i], 0, sizeof(struct ff_effect));
 			}
 			drv_data->client.current_id = 0;
 		}

--- a/hid-ftec.h
+++ b/hid-ftec.h
@@ -87,6 +87,15 @@ struct ftec_tuning_classdev {
 	u8 advanced_mode;
 };
 
+struct ftec_drv_data_client {
+	struct hid_device *hdev;
+	u8 rdesc[4096];
+	size_t rsize;
+	int opened;
+	struct ff_effect effects[6];
+	struct ff_effect *current_effect;
+};
+
 struct ftec_drv_data {
 	unsigned long quirks;
 	spinlock_t report_lock; /* Protect output HID report */
@@ -94,6 +103,7 @@ struct ftec_drv_data {
 	struct hrtimer hrtimer;
 	struct hid_device *hid;
 	struct hid_report *report;
+	struct ftec_drv_data_client client;
 	struct ftecff_slot slots[5];
 	struct ftecff_effect_state states[FTECFF_MAX_EFFECTS];
 	int effects_used;	

--- a/hid-ftec.h
+++ b/hid-ftec.h
@@ -92,8 +92,8 @@ struct ftec_drv_data_client {
 	u8 rdesc[4096];
 	size_t rsize;
 	int opened;
-	struct ff_effect effects[6];
-	struct ff_effect *current_effect;
+	struct ff_effect effects[40];
+	u8 current_id;
 };
 
 struct ftec_drv_data {


### PR DESCRIPTION
This is the driver part of fixing #67, see [my comment there](https://github.com/gotzl/hid-fanatecff/issues/67#issuecomment-2183336753) for details. There is also the wine part, which adds the multi TLC support ([see this MR](https://gitlab.winehq.org/wine/wine/-/merge_requests/6074)).

Multi TLC support in wine will require to access the device via HIDRAW. To get FFB working with HIDRAW, the Linux driver extends the HID descriptor that's exposed on the HIDRAW device with a HID PID descriptor. Wine understands this descriptor and sends FFB commands via HID PID packets. The linux driver has to filter out these HID PID packets and feed them to the Linux FFB code. Other HID packets are passed directly to the device.

Using HIDRAW for Fanatec devices in wine also has the benefit that the FanatecSDK can talk to the device. This means that for games that include the FanatecSDK, LEDs and displays would just work. I've tested this already with Rennsport and F1 23. F1 23 also used the 'Flag LEDs', so this PR could also be a partial fix for #38. F1 23 however lacks forces from tyres (self-alignment/traction).

Edit: Tested with ACC, which uses FanatecSDK to drive RPM LEDs, Flag LEDs (ABS, TC), and shows Speed/Gear in the display. Preliminary testing showed also an improvement on #70.
R3E drives RPM Leds, Flag LELDs (eg yellow flags) and shows Speed in the display.