### PR TITLE
Explain full paths for LEDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Advanced functions of wheels/bases are available via sysfs. Generally, these fil
 
 #### CSL Elite Base
 
-* RPM LEDs: `leds/0003:0EB7:0005.*::RPMx/brightness` (x from 1 to 9)
+* RPM LEDs: `/sys/class/leds/0003:0EB7:0005.*::RPMx/brightness` (x from 1 to 9)
 
 #### ClubSport Forumla1 wheel
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Advanced functions of wheels/bases are available via sysfs. Generally, these fil
 * RPM LEDs: `/sys/module/hid_fanatec/drivers/hid:fanatec/0003:0EB7:<PID>.*/leds/0003:0EB7:0005.*::RPMx/brightness`  
   Or in path: `/sys/class/leds/0003:0EB7:0005.*::RPMx/brightness` (x from 1 to 9)
 
-#### ClubSport Forumla1 wheelcd 
+#### ClubSport Forumla1 
 
 * RPM LEDs (combined with base)
 * Display: `display` (negative value turns display off)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Advanced functions of wheels/bases are available via sysfs. Generally, these fil
 * RPM LEDs: `/sys/module/hid_fanatec/drivers/hid:fanatec/0003:0EB7:<PID>.*/leds/0003:0EB7:0005.*::RPMx/brightness`  
   Or in path: `/sys/class/leds/0003:0EB7:0005.*::RPMx/brightness` (x from 1 to 9)
 
-#### ClubSport Forumla1 
+#### ClubSport Forumla1 wheel
 
 * RPM LEDs (combined with base)
 * Display: `display` (negative value turns display off)

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ Advanced functions of wheels/bases are available via sysfs. Generally, these fil
 
 #### CSL Elite Base
 
-* RPM LEDs: `/sys/class/leds/0003:0EB7:0005.*::RPMx/brightness` (x from 1 to 9)
+* RPM LEDs: `/sys/module/hid_fanatec/drivers/hid:fanatec/0003:0EB7:<PID>.*/leds/0003:0EB7:0005.*::RPMx/brightness`  
+  Or in path: `/sys/class/leds/0003:0EB7:0005.*::RPMx/brightness` (x from 1 to 9)
 
-#### ClubSport Forumla1 wheel
+#### ClubSport Forumla1 wheelcd 
 
 * RPM LEDs (combined with base)
 * Display: `display` (negative value turns display off)


### PR DESCRIPTION
Missing `/sys/class/` to the path.. I needed to search a bit where the leds where, but I think it's better to write out the full path.