### PR TITLE
Add build artifacts to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Kernel Module artifacts
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf


### PR DESCRIPTION
Introduce a `.gitignore` file, which should ignore both the object and kernel module build artifact files.