### PR TITLE
Analog Clutch Paddle Mode Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,16 @@ Advanced functions of wheels/bases are available via sysfs. Generally, these fil
 * Tuning menu (experimental): `tuning_menu/*` 
   * Get/set 'standard'/'advanced' mode: `andvanced_mode`
   * Get/set tuning menu slot: echo number into `SLOT`
-  * Values get/set: `BLI DPR DRI FEI FF FOR SEN SHO SPR ...` (files depend on wheel-base)
   * Reset all tuning sets by echoing anything into `RESET`
+  * Values get/set: `BLI DPR DRI FEI FF FOR SEN SHO SPR ...` (files depend on wheel-base)
+  * Force Feedback Scaling `FFS` (not available on all DD wheel bases)
+    * `0` `Lin` Linear mode
+    * `1` Peak mode (default)
+  * Analogue Paddles `ACP` (read only on wheels with mode selector switch)
+    * `1` `CbP`: Clutch bite point left & right, paddle work in parallel (default)
+    * `2` `CH`: Clutch / Handbrake
+    * `3` `Bt`: Brake / Throttle
+    * `4` `AnA`: Mappable analog axes, shared and interferes with analog ministick if present
 
 ### CSL Elite Base
 

--- a/fanatec.rules
+++ b/fanatec.rules
@@ -21,7 +21,7 @@ GOTO="fanatec_end"
 LABEL="ftec_tuning_settings"
 # let everyone in games group read/write tuning-menu entries
 # FIXME: this should be narrowed down in the future! Also, this fires every time a value is changed!
-RUN+="/bin/sh -c 'cd %S%p && chown -f :games advanced_mode RESET SLOT SEN FF SHO BLI DRI FOR SPR DPR NDP NFR FEI INT NIN FUL FFS || true'"
+RUN+="/bin/sh -c 'cd %S%p && chown -f :games advanced_mode RESET SLOT SEN FF SHO BLI DRI FOR SPR DPR NDP NFR FEI INT NIN FUL FFS ACP || true'"
 GOTO="fanatec_end"
 
 LABEL="fanatec_end"

--- a/hid-ftec.h
+++ b/hid-ftec.h
@@ -134,6 +134,7 @@ struct ftec_drv_data {
 	FTEC_TUNING_ATTR(NDP, 0x0d, "Natural Damber", ftec_conv_noop_to, ftec_conv_noop_from, 0, 100) \
 	FTEC_TUNING_ATTR(NFR, 0x0e, "Natural Friction", ftec_conv_noop_to, ftec_conv_noop_from, 0, 100) \
 	FTEC_TUNING_ATTR(FEI, 0x11, "Force Effect Intensity", ftec_conv_noop_to, ftec_conv_steps_ten, 0, 100) \
+	FTEC_TUNING_ATTR(ACP, 0x13, "Analogue Paddles", ftec_conv_noop_to, ftec_conv_noop_from, 1, 4) \
 	FTEC_TUNING_ATTR(INT, 0x14, "FFB Interpolation Filter", ftec_conv_noop_to, ftec_conv_noop_from, 0, 20) \
 	FTEC_TUNING_ATTR(NIN, 0x15, "Natural Inertia", ftec_conv_noop_to, ftec_conv_noop_from, 0, 100) \
 	FTEC_TUNING_ATTR(FUL, 0x16, "FullForce", ftec_conv_noop_to, ftec_conv_noop_from, 0, 100) \

--- a/hid-ftecff-tuning.c
+++ b/hid-ftecff-tuning.c
@@ -271,6 +271,7 @@ int ftec_tuning_classdev_register(struct device *parent,
 	CREATE_SYSFS_FILE(FOR)
 	CREATE_SYSFS_FILE(SPR)
 	CREATE_SYSFS_FILE(DPR)
+	CREATE_SYSFS_FILE(ACP)
 
 	if (hdev->product == CSL_ELITE_WHEELBASE_DEVICE_ID || 
 	    hdev->product == CSL_ELITE_PS4_WHEELBASE_DEVICE_ID) {
@@ -321,6 +322,7 @@ void ftec_tuning_classdev_unregister(struct ftec_tuning_classdev *ftec_tuning_cd
 	REMOVE_SYSFS_FILE(FOR)
 	REMOVE_SYSFS_FILE(SPR)
 	REMOVE_SYSFS_FILE(DPR)
+    REMOVE_SYSFS_FILE(ACP)
 
 	if (hdev->product == CSL_ELITE_WHEELBASE_DEVICE_ID || 
 	    hdev->product == CSL_ELITE_PS4_WHEELBASE_DEVICE_ID) {


### PR DESCRIPTION
I briefly had the `Advanced Paddle Module` installed on a podium hub and also on a F1 Clubsport wheel and checked which unused bits changed the paddle operation.

Findings:
- In the Podium Hub without any display , clutch bite mode is almost unusable because the inputs are invisible
- The F1 wheel shows a new menu point ACP with 4 operating modes described in the readme
- Unsure how to detect this, without the module I still seem to be able to set the mode without it showing on the wheel with display, and the default mode after RESET is still `1` / `CbP`

My understanding is that the value will be read-only/overwritten if a wheel or module is installed that sets the paddle mode by a selector switch (GT3 style / higher tier F1 wheels / rally module etc.)

