### PR TITLE
Experimental fix for older isiMotor games

### DIFF
--- a/hid-ftec.c
+++ b/hid-ftec.c
@@ -589,8 +589,9 @@ handle_pid_set_periodic(struct ftec_drv_data *drv_data, struct hid_device *hdev,
 	      params->period, params->magnitude, params->offset, params->phase);
 
 	effect->u.periodic.period = params->period == 0xffff ? 0 : params->period;
-	// NOTE: some games abuse periodic to actually send constant force
-	if (effect->u.periodic.period != 0) {
+	// NOTE: some games abuse periodic to send constant force. gMotor/ISI sims (GTR2)
+	// use a zero-magnitude Sine with the force in the DC offset -> route to constant.
+	if (effect->u.periodic.period != 0 && params->magnitude != 0) {
 		effect->u.periodic.magnitude = params->magnitude;
 		effect->u.periodic.offset = params->offset;
 		effect->u.periodic.phase = 0x10000ULL * params->phase / 360;

--- a/hid-ftecff.c
+++ b/hid-ftecff.c
@@ -744,9 +744,19 @@ static void ftecff_update_slot(struct ftecff_slot *slot,
 	case FF_DAMPER:
 	case FF_INERTIA:
 	case FF_FRICTION:
-		slot->current_cmd[2] = SCALE_COEFF(parameters->k1, 4);
-		slot->current_cmd[4] = SCALE_COEFF(parameters->k2, 4);
-		slot->current_cmd[6] = SCALE_VALUE_U16(parameters->clip, 8);
+		// On DD1, the legacy 4-bit coeff (max 0x0f) was too weak to feel; an
+		// 8-bit coeff in byte 2/4 produces clear resistance. Non-zero byte 3/5
+		// caused oscillation instead of damping, so keep them zero. Applied to
+		// highres bases; other models untested.
+		if (highres) {
+			slot->current_cmd[2] = SCALE_COEFF(parameters->k1, 8);
+			slot->current_cmd[4] = SCALE_COEFF(parameters->k2, 8);
+			slot->current_cmd[6] = SCALE_VALUE_U16(parameters->clip, 8);
+		} else {
+			slot->current_cmd[2] = SCALE_COEFF(parameters->k1, 4);
+			slot->current_cmd[4] = SCALE_COEFF(parameters->k2, 4);
+			slot->current_cmd[6] = SCALE_VALUE_U16(parameters->clip, 8);
+		}
 		break;
 	}
 


### PR DESCRIPTION
This PR fixes some issues I hit testing GTR2 on DD1.  I suspect this _may_ also help rFactor 1 and F1C games.

* GTR2 submits steering as a zero-magnitude periodic (Sine) effect with the force in the DC offset. The driver treated it as constant force but read the (zero) magnitude instead of the offset, resulting almost no FFB. Now a zero-magnitude periodic is routed to constant force using the offset.

* Friction/Damper were far too weak on the DD1 — the coefficient was scaled to only 4 bits. I widened it to 8 bits (per side) for highres bases. Not fully solved: FFB feelss weaker around center than on Windows, and the Spring effect looks similarly clamped to 4-bit, but I am not 100% sure yet.

Likely fixes: https://github.com/gotzl/hid-fanatecff/issues/116
